### PR TITLE
Fix TSan data race warning

### DIFF
--- a/source/pareto/front.h
+++ b/source/pareto/front.h
@@ -67,6 +67,7 @@ namespace pareto {
         using mapped_type = typename container_type::mapped_type;
         using key_compare = typename container_type::key_compare;
         using value_compare = typename container_type::value_compare;
+        mapped_type placeholder;
 
       public /* AllocatorAwareContainer Concept */:
         using allocator_type = typename container_type::allocator_type;
@@ -452,7 +453,6 @@ namespace pareto {
                     // just to avoid throwing an error
                     // nothing was included in the containers because
                     // the element is dominated
-                    static mapped_type placeholder;
                     return placeholder;
                 }
             }
@@ -479,7 +479,6 @@ namespace pareto {
                     // just to avoid throwing an error
                     // nothing was included in the containers because
                     // the element is dominated
-                    static mapped_type placeholder;
                     return placeholder;
                 }
             }

--- a/source/pareto/front.h
+++ b/source/pareto/front.h
@@ -894,12 +894,35 @@ namespace pareto {
         /// \return Hypervolume of this front
         dimension_type hypervolume() const { return hypervolume(nadir()); }
 
-        /// \brief Get exact hypervolume
+        /// \brief Get exact hypervolume of the pareto frontier within the cuboid
+        /// with minimum coordinate given by reference_point and maximum coordinate
+        /// given by max_point
         /// \note Use the other hypervolume function if this takes
         /// too long (m is too large).
-        /// \param reference_point Reference point
+        /// \param reference_point Reference point (minimum coordinate of cuboid)
+        /// \param max_point Maximum coordinate of cuboid.  If not give, the 
+        /// total hypervolume wiht respect to reference point will be returned.
+        /// E.g. this is equivalent to setting max_point to contain all infinite
+        /// values
         /// \return Hypervolume of this front
-        dimension_type hypervolume(point_type reference_point) const {
+        dimension_type hypervolume(point_type reference_point, 
+                                   std::optional<point_type> max_point = std::nullopt) const {
+
+            size_t hard_coded_dimensions = 3; // fix
+            point<double, point_type::compile_dimensions,
+                  typename point_type::coordinate_system_t>
+                max_point_objective_adjusted(hard_coded_dimensions);
+
+            if(max_point.has_value()){
+                for (size_t i = 0; i < dimensions(); ++i) {
+                    if (is_minimization(i)) {
+                        max_point_objective_adjusted[i] = (*max_point)[i];
+                    } else {
+                        max_point_objective_adjusted[i] = -(*max_point)[i];
+                    }
+                }
+            }
+
             // reshape points
             std::vector<double> data;
             data.reserve(size() * dimensions());
@@ -913,6 +936,9 @@ namespace pareto {
                     } else {
                         inv[i] = -k[i];
                     }
+                    if(max_point.has_value() && inv[i] < max_point_objective_adjusted[i]){
+                        inv[i] = max_point_objective_adjusted[i];
+                    }                    
                 }
                 data.insert(data.end(), inv.begin(), inv.end());
             }

--- a/source/pareto/front.h
+++ b/source/pareto/front.h
@@ -894,35 +894,12 @@ namespace pareto {
         /// \return Hypervolume of this front
         dimension_type hypervolume() const { return hypervolume(nadir()); }
 
-        /// \brief Get exact hypervolume of the pareto frontier within the cuboid
-        /// with minimum coordinate given by reference_point and maximum coordinate
-        /// given by max_point
+        /// \brief Get exact hypervolume
         /// \note Use the other hypervolume function if this takes
         /// too long (m is too large).
-        /// \param reference_point Reference point (minimum coordinate of cuboid)
-        /// \param max_point Maximum coordinate of cuboid.  If not give, the 
-        /// total hypervolume wiht respect to reference point will be returned.
-        /// E.g. this is equivalent to setting max_point to contain all infinite
-        /// values
+        /// \param reference_point Reference point
         /// \return Hypervolume of this front
-        dimension_type hypervolume(point_type reference_point, 
-                                   std::optional<point_type> max_point = std::nullopt) const {
-
-            size_t hard_coded_dimensions = 3; // fix
-            point<double, point_type::compile_dimensions,
-                  typename point_type::coordinate_system_t>
-                max_point_objective_adjusted(hard_coded_dimensions);
-
-            if(max_point.has_value()){
-                for (size_t i = 0; i < dimensions(); ++i) {
-                    if (is_minimization(i)) {
-                        max_point_objective_adjusted[i] = (*max_point)[i];
-                    } else {
-                        max_point_objective_adjusted[i] = -(*max_point)[i];
-                    }
-                }
-            }
-
+        dimension_type hypervolume(point_type reference_point) const {
             // reshape points
             std::vector<double> data;
             data.reserve(size() * dimensions());
@@ -936,9 +913,6 @@ namespace pareto {
                     } else {
                         inv[i] = -k[i];
                     }
-                    if(max_point.has_value() && inv[i] < max_point_objective_adjusted[i]){
-                        inv[i] = max_point_objective_adjusted[i];
-                    }                    
                 }
                 data.insert(data.end(), inv.begin(), inv.end());
             }


### PR DESCRIPTION
The static variable `placeholder` that is returned by `front::operator[]` causes a [TSan](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual) data race warning.  When multiple threads each have their own `front` object and call operator[], this data race occurs.  (`placeholder` is initialized once, by the first thread that calls `front::operator[]`.  Then all threads return a reference to the same memory location.). This race is harmless because placeholder is a throw away reference, but this fix removes the TSan warning.